### PR TITLE
ScrollingDataTable changes the configuration value of scrollable to false

### DIFF
--- a/build/datatable/datatable.js
+++ b/build/datatable/datatable.js
@@ -15902,6 +15902,7 @@ widget.ScrollingDataTable = function(elContainer,aColumnDefs,oDataSource,oConfig
     
     // Prevent infinite loop
     if(oConfigs.scrollable) {
+    	oConfigs = lang.merge(oConfigs);
         oConfigs.scrollable = false;
     }
 


### PR DESCRIPTION
...instantiation. If using a wrapper around the datatable object in which you want to keep the original object values makes this change important. It's a bad behavior to change incoming variable values.
