### PR TITLE
fix Calendar bug for new Russian timezones

### DIFF
--- a/src/datemath/js/DateMath.js
+++ b/src/datemath/js/DateMath.js
@@ -340,7 +340,7 @@ YAHOO.widget.DateMath = {
     * @return {Date}  The JavaScript Date representing the first day of the month
     */
     findMonthStart : function(date) {
-        var start = this.getDate(date.getFullYear(), date.getMonth(), 1);
+        var start = this.getDate(date.getFullYear(), date.getMonth(), 1, 12);
         return start;
     },
 


### PR DESCRIPTION
I'm opening this PR for reference for poor souls who still have YUI2 apps.

**You might be likely interested in it if you have Windows-based customers (using Firefox) in Russia.**

---

This commit fixes a bug manifesting itself in Calendar widget
due to recent permanent timezone changes in Russia
- affected browser: Firefox (any version, including 33-36) and Safari
  5.1.7 for Windows
- operating system: Windows 7 with the patches from August 2014 announced on
  http://blogs.technet.com/b/dst2007/archive/2014/08/22/announcement-update-for-russian-time-zone-changes.aspx
- set your timezone to "(UTC+03:00) Moscow, St. Petersburg, Volgograd (RTZ 2)"
- set your operating system date between 1 Nov 2014 and 31 Dec 2014
- open http://yui.github.io/yui2/docs/yui_2.9.0_full/examples/calendar/quickstart.html
- navigate to December 2014

Then, click ">" to move to next month.
You expected to see January 2015 but December 2015 was displayed instead.

Under the hood, the problem is that the following JS:

```
new Date((new Date(2014,11,1).setMonth(0))).getFullYear()
```

evaluates to `2013` in Firefox in the mentioned locale
(the exact date is Tue Dec 31 2013 23:00:00 GMT+0300)
It evaluates to `2014` in Chrome 38 and IE9.

In the YUI2 Calendar code, the dates are initialized with "12:00:00" hour
to avoid DST-related problems, but the `findMonthStart` method was
returning a date with "00:00:00" time, this was propagated and hence
from certain point of calendar lifetime, all the dates had hour reset
to "00:00:00".

The fix changes the dates returned by `findMonthStart` to be also midday
instead of midnight which solves the Russian timezone change-related
problems and perhaps some other similar types of problems.
